### PR TITLE
return OptionsConfigurer from EnableDiagnosticSources

### DIFF
--- a/Rebus.Diagnostics/Config/DiagnosticSourcesConfigurationExtensions.cs
+++ b/Rebus.Diagnostics/Config/DiagnosticSourcesConfigurationExtensions.cs
@@ -9,7 +9,7 @@ namespace Rebus.Config
 {
     public static class DiagnosticSourcesConfigurationExtensions
     {
-        public static void EnableDiagnosticSources(this OptionsConfigurer configurer)
+        public static OptionsConfigurer EnableDiagnosticSources(this OptionsConfigurer configurer)
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
 
@@ -32,6 +32,7 @@ namespace Rebus.Config
                 
                 return concatenator;
             });
+            return configurer;
         }
     }
 }


### PR DESCRIPTION
When configuring Rebus I noticed the OptionsConfigurer Extensions did not return the OptionsCopnfigurer object after making the change. When changing multiple options, this syntax allows for cleaner code in my opinion.