### PR TITLE
Update System.Diagnostics.DiagnosticSource version range

### DIFF
--- a/Rebus.Diagnostics/Rebus.Diagnostics.csproj
+++ b/Rebus.Diagnostics/Rebus.Diagnostics.csproj
@@ -31,6 +31,6 @@
 	
   <ItemGroup>
 		<PackageReference Include="Rebus" Version="8.0.1" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[6, 9)" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[6, 10)" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Currently in the process of upgrading to .NET 9 and run into the same problem as described in #21