### PR TITLE
Forward exceptions and add a bit more data to traces

### DIFF
--- a/Rebus.Diagnostics.Tests/Incoming/HandlerInvokerWrapperTests.cs
+++ b/Rebus.Diagnostics.Tests/Incoming/HandlerInvokerWrapperTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Rebus.Diagnostics.Incoming;
@@ -39,6 +41,40 @@ namespace Rebus.Diagnostics.Tests.Incoming
 
             Assert.That(innerInvokerWasInvoked);
             Assert.That(hadActivity);
+        }
+
+        [Test]
+        public async Task MarksActivityAsFailedIfHandlerThrows()
+        {
+            using var activity = new Activity("MyActivity");
+
+            Activity? innerActivity = null;
+            var innerInvoker = new TestInvoker(() =>
+            {
+                innerActivity = Activity.Current;
+                throw new Exception("Look im failing");
+            });
+
+            var wrapper = new HandlerInvokerWrapper(innerInvoker, "MyMessage");
+
+            activity.Start();
+
+            Assume.That(activity, Is.SameAs(Activity.Current));
+
+            Assert.That(async () =>
+            {
+                await wrapper.Invoke();
+            }, Throws.Exception);
+
+            
+            Assert.That(innerActivity, Is.Not.Null);
+
+            Assert.That(innerActivity!.Status, Is.EqualTo(ActivityStatusCode.Error));
+            Assert.That(innerActivity!.StatusDescription, Is.EqualTo("Look im failing"));
+            Assert.That(innerActivity.Events, Has.Exactly(1).Items);
+            var ev = innerActivity.Events.Single();
+            Assert.That(ev.Tags.FirstOrDefault(t => t.Key == "exception.type").Value, Is.EqualTo("System.Exception"));
+            Assert.That(ev.Tags.FirstOrDefault(t => t.Key == "exception.message").Value, Is.EqualTo("Look im failing"));
         }
 
         [Test]

--- a/Rebus.Diagnostics.Tests/Incoming/HandlerInvokerWrapperTests.cs
+++ b/Rebus.Diagnostics.Tests/Incoming/HandlerInvokerWrapperTests.cs
@@ -44,7 +44,7 @@ namespace Rebus.Diagnostics.Tests.Incoming
         }
 
         [Test]
-        public async Task MarksActivityAsFailedIfHandlerThrows()
+        public void MarksActivityAsFailedIfHandlerThrows()
         {
             using var activity = new Activity("MyActivity");
 

--- a/Rebus.Diagnostics.Tests/Incoming/IncomingDiagnosticsStepTests.cs
+++ b/Rebus.Diagnostics.Tests/Incoming/IncomingDiagnosticsStepTests.cs
@@ -331,7 +331,7 @@ namespace Rebus.Diagnostics.Tests.Incoming
         /// <summary>
         ///     Formatter function that is invoked for each object value to be rendered into a string while interpolating log lines
         /// </summary>
-        private string FormatObject(object obj, string format)
+        private string FormatObject(object obj, string? format)
         {
             if (obj is string) return $@"""{obj}""";
             if (obj is IEnumerable)
@@ -345,7 +345,7 @@ namespace Rebus.Diagnostics.Tests.Incoming
             if (obj is DateTimeOffset) return ((DateTimeOffset) obj).ToString(format ?? "O");
             if (obj is IFormattable) return ((IFormattable) obj).ToString(format, CultureInfo.InvariantCulture);
             if (obj is IConvertible) return ((IConvertible) obj).ToString(CultureInfo.InvariantCulture);
-            return obj.ToString();
+            return obj.ToString()!;
         }
 
         #endregion

--- a/Rebus.Diagnostics.Tests/Outgoing/OutgoingDiagnosticsStepTests.cs
+++ b/Rebus.Diagnostics.Tests/Outgoing/OutgoingDiagnosticsStepTests.cs
@@ -15,7 +15,7 @@ namespace Rebus.Diagnostics.Tests.Outgoing
     [TestFixture]
     public class OutgoingDiagnosticsStepTests : FixtureBase
     {
-        RebusTransactionScope? _scope;
+        RebusTransactionScope _scope = null!;
 
         [OneTimeSetUp]
         public static void ListenForRebus()

--- a/Rebus.Diagnostics/Diagnostics/Helpers/ActivityExtensions.cs
+++ b/Rebus.Diagnostics/Diagnostics/Helpers/ActivityExtensions.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Rebus.Diagnostics.Helpers;
+
+internal static class ActivityExtensions
+{
+    
+    const string ExceptionEventName = "exception";
+    const string ExceptionMessageTag = "exception.message";
+    const string ExceptionStackTraceTag = "exception.stacktrace";
+    const string ExceptionTypeTag = "exception.type";
+
+    
+    // "Borrowed" from https://github.com/tarekgh/runtime/blob/d4464d7ae6d99d75ff89309fb56fd2a5a8f0c845/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs#L535
+    // to avoid requiring version 9 of System.Diagnostics.DiagnosticSource
+    public static Activity AddException(this Activity activity, Exception exception,
+        ActivityTagsCollection? tags = null, DateTimeOffset timestamp = default)
+    {
+        if (exception == null)
+        {
+            throw new ArgumentNullException(nameof(exception));
+        }
+
+        var exceptionTags = tags ?? new();
+
+        var hasMessage = false;
+        var hasStackTrace = false;
+        var hasType = false;
+
+        foreach (var pair in exceptionTags)
+        {
+            if (pair.Key == ExceptionMessageTag)
+            {
+                hasMessage = true;
+            }
+            else if (pair.Key == ExceptionStackTraceTag)
+            {
+                hasStackTrace = true;
+            }
+            else if (pair.Key == ExceptionTypeTag)
+            {
+                hasType = true;
+            }
+        }
+
+        if (!hasMessage)
+        {
+            exceptionTags.Add(new KeyValuePair<string, object?>(ExceptionMessageTag, exception.Message));
+        }
+
+        if (!hasStackTrace)
+        {
+            exceptionTags.Add(new KeyValuePair<string, object?>(ExceptionStackTraceTag, exception.ToString()));
+        }
+
+        if (!hasType)
+        {
+            exceptionTags.Add(new KeyValuePair<string, object?>(ExceptionTypeTag, exception.GetType().ToString()));
+        }
+
+        return activity.AddEvent(new ActivityEvent(ExceptionEventName, timestamp, exceptionTags));
+    }
+}

--- a/Rebus.Diagnostics/Diagnostics/Helpers/MessageWrapper.cs
+++ b/Rebus.Diagnostics/Diagnostics/Helpers/MessageWrapper.cs
@@ -25,6 +25,11 @@ internal abstract class MessageWrapper
     {
         return Headers.GetValueOrNull(Rebus.Messages.Headers.Intent) ?? GetMessageId();
     }
+
+    internal string GetMessageType()
+    {
+        return Headers.GetValueOrNull(Rebus.Messages.Headers.Type) ?? "";
+    }
 }
 
 internal class TransportMessageWrapper : MessageWrapper

--- a/Rebus.Diagnostics/Diagnostics/Helpers/TagHelper.cs
+++ b/Rebus.Diagnostics/Diagnostics/Helpers/TagHelper.cs
@@ -18,6 +18,7 @@ internal static class TagHelper
         initialTags.Add("messaging.destination_kind", kind);
         initialTags.Add("messaging.message_id", message.GetMessageId());
         initialTags.Add("messaging.conversation_id", message.GetCorrectionId());
+        initialTags.Add("rebus.message.type", message.GetMessageType());
 
         return initialTags;
     }

--- a/Rebus.Diagnostics/Diagnostics/Incoming/HandlerInvokerWrapper.cs
+++ b/Rebus.Diagnostics/Diagnostics/Incoming/HandlerInvokerWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Rebus.Diagnostics.Helpers;
 using Rebus.Pipeline.Receive;
@@ -34,12 +35,22 @@ internal class HandlerInvokerWrapper : HandlerInvoker
                 initialTags.Add(tag.Key, tag.Value);
         }
         initialTags["messaging.operation"] = "process";
-            
+        initialTags["rebus.handler.type"] = _handlerInvokerImplementation.Handler.GetType().FullName;
+
         using var activity = RebusDiagnosticConstants.ActivitySource.StartActivity($"{_messageType} process", ActivityKind.Internal, parentActivity.Context, initialTags);
             
         TagHelper.CopyBaggage(parentActivity, activity);
-            
-        await _handlerInvokerImplementation.Invoke();
+
+        try
+        {
+            await _handlerInvokerImplementation.Invoke();
+        }
+        catch (Exception e)
+        {
+            activity?.AddException(e);
+            activity?.SetStatus(ActivityStatusCode.Error, e.ToString());
+            throw;
+        }
     }
 
     public override void SetSagaData(ISagaData sagaData)

--- a/Rebus.Diagnostics/Diagnostics/Incoming/HandlerInvokerWrapper.cs
+++ b/Rebus.Diagnostics/Diagnostics/Incoming/HandlerInvokerWrapper.cs
@@ -35,7 +35,7 @@ internal class HandlerInvokerWrapper : HandlerInvoker
                 initialTags.Add(tag.Key, tag.Value);
         }
         initialTags["messaging.operation"] = "process";
-        initialTags["rebus.handler.type"] = _handlerInvokerImplementation.Handler.GetType().FullName;
+        initialTags["rebus.handler.type"] = _handlerInvokerImplementation.Handler?.GetType().FullName ?? "Unknown handler type";
 
         using var activity = RebusDiagnosticConstants.ActivitySource.StartActivity($"{_messageType} process", ActivityKind.Internal, parentActivity.Context, initialTags);
             
@@ -48,7 +48,7 @@ internal class HandlerInvokerWrapper : HandlerInvoker
         catch (Exception e)
         {
             activity?.AddException(e);
-            activity?.SetStatus(ActivityStatusCode.Error, e.ToString());
+            activity?.SetStatus(ActivityStatusCode.Error, e.Message);
             throw;
         }
     }


### PR DESCRIPTION
I actually though the Diagnostic Activities themselves would capture this in case they were unwinding an exception in dispose, but apparently not. 
It might be something that is new with .net 9, however who knows. For now we will do it ourselves. 